### PR TITLE
Add vanilla JS calculator with tests and tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.DS_Store
+npm-debug.log*
+.env

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "none"
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# calculator-web
+# バニラJS Web電卓
+
+バニラHTML/CSS/JavaScriptで実装したシンプルなWeb電卓です。加減乗除や少数、クリア、Backspace、Enterキーでの計算に対応しています。Node.jsの標準テストランナーとESLint/Prettierで品質を担保します。
+
+## セットアップ
+
+```bash
+npm install
+```
+
+## 利用方法
+
+1. `index.html` をブラウザで開きます。
+2. 画面上のボタン、もしくはキーボードの数字・演算子・Enter・Backspace・Escで入力できます。
+
+## スクリプト
+
+| コマンド | 説明 |
+| --- | --- |
+| `npm test` | Node.js標準テストランナーでユニットテストを実行します。 |
+| `npm run lint` | ESLintで静的解析を行います。 |
+| `npm run format` | Prettierでコードフォーマットをチェックします。 |
+| `npm run format:write` | Prettierでコードを自動整形します。 |
+
+## テスト
+
+`test/calc.test.js` にCalculatorクラスのユニットテストが用意されています。`node --test`で動作します。
+
+## ライセンス
+
+このプロジェクトは[MIT License](LICENSE)で提供されています。

--- a/app.js
+++ b/app.js
@@ -1,0 +1,104 @@
+import { Calculator } from './calc.js';
+
+const calculator = new Calculator();
+const display = document.querySelector('[data-display]');
+const keys = document.querySelector('.calculator__keys');
+
+function updateDisplay() {
+  if (!display) return;
+  display.textContent = calculator.getDisplayValue();
+}
+
+function handleAction(action) {
+  switch (action) {
+    case 'clear':
+      calculator.clear();
+      break;
+    case 'backspace':
+      calculator.backspace();
+      break;
+    case 'equals':
+      calculator.evaluate();
+      break;
+    case 'decimal':
+      calculator.inputDecimal();
+      break;
+    default:
+      break;
+  }
+  updateDisplay();
+}
+
+function handleOperator(operator) {
+  calculator.setOperator(operator);
+  updateDisplay();
+}
+
+function handleDigit(digit) {
+  calculator.inputDigit(digit);
+  updateDisplay();
+}
+
+if (keys) {
+  keys.addEventListener('click', (event) => {
+    const button = event.target.closest('button');
+    if (!button) {
+      return;
+    }
+
+    if (button.dataset.digit) {
+      handleDigit(button.dataset.digit);
+      return;
+    }
+
+    if (button.dataset.operator) {
+      handleOperator(button.dataset.operator);
+      return;
+    }
+
+    if (button.dataset.action) {
+      handleAction(button.dataset.action);
+    }
+  });
+}
+
+document.addEventListener('keydown', (event) => {
+  const { key } = event;
+
+  if (/^[0-9]$/.test(key)) {
+    event.preventDefault();
+    handleDigit(key);
+    return;
+  }
+
+  if (key === '.') {
+    event.preventDefault();
+    handleAction('decimal');
+    return;
+  }
+
+  if (key === 'Enter' || key === '=') {
+    event.preventDefault();
+    handleAction('equals');
+    return;
+  }
+
+  if (key === 'Backspace') {
+    event.preventDefault();
+    handleAction('backspace');
+    return;
+  }
+
+  if (key === 'Escape') {
+    event.preventDefault();
+    handleAction('clear');
+    return;
+  }
+
+  if (['+', '-', '*', '/'].includes(key)) {
+    event.preventDefault();
+    handleOperator(key);
+  }
+});
+
+updateDisplay();

--- a/calc.js
+++ b/calc.js
@@ -1,0 +1,157 @@
+const MAX_DISPLAY_LENGTH = 12;
+
+function formatNumber(value) {
+  if (value === null || Number.isNaN(value)) {
+    return 'Error';
+  }
+
+  if (!Number.isFinite(value)) {
+    return value > 0 ? '∞' : '-∞';
+  }
+
+  const rounded = Number.parseFloat(value.toFixed(10));
+  let output = rounded.toString();
+
+  if (output.includes('e')) {
+    return rounded.toExponential(6);
+  }
+
+  if (output.length > MAX_DISPLAY_LENGTH) {
+    output = rounded.toPrecision(6);
+  }
+
+  return output;
+}
+
+export class Calculator {
+  constructor() {
+    this.clear();
+  }
+
+  clear() {
+    this.currentOperand = '0';
+    this.previousOperand = null;
+    this.operator = null;
+    this.shouldResetCurrent = false;
+    return this.currentOperand;
+  }
+
+  inputDigit(digit) {
+    if (!/^[0-9]$/.test(digit)) {
+      return this.currentOperand;
+    }
+
+    if (this.currentOperand === 'Error' || this.shouldResetCurrent) {
+      this.currentOperand = digit;
+      this.shouldResetCurrent = false;
+      return this.currentOperand;
+    }
+
+    if (this.currentOperand === '0') {
+      this.currentOperand = digit;
+    } else if (this.currentOperand.length < MAX_DISPLAY_LENGTH) {
+      this.currentOperand += digit;
+    }
+
+    return this.currentOperand;
+  }
+
+  inputDecimal() {
+    if (this.currentOperand === 'Error' || this.shouldResetCurrent) {
+      this.currentOperand = '0.';
+      this.shouldResetCurrent = false;
+      return this.currentOperand;
+    }
+
+    if (!this.currentOperand.includes('.')) {
+      this.currentOperand += '.';
+    }
+
+    return this.currentOperand;
+  }
+
+  backspace() {
+    if (this.currentOperand === 'Error') {
+      return this.clear();
+    }
+
+    if (this.shouldResetCurrent) {
+      this.currentOperand = '0';
+      this.shouldResetCurrent = false;
+      return this.currentOperand;
+    }
+
+    if (this.currentOperand.length <= 1) {
+      this.currentOperand = '0';
+    } else {
+      this.currentOperand = this.currentOperand.slice(0, -1);
+    }
+
+    return this.currentOperand;
+  }
+
+  setOperator(operator) {
+    if (!['+', '-', '*', '/'].includes(operator)) {
+      return this.currentOperand;
+    }
+
+    if (this.operator && !this.shouldResetCurrent) {
+      const result = this.#compute();
+      this.currentOperand = formatNumber(result);
+      if (this.currentOperand === 'Error') {
+        this.previousOperand = null;
+        this.operator = null;
+        this.shouldResetCurrent = true;
+        return this.currentOperand;
+      }
+      this.previousOperand = Number.parseFloat(this.currentOperand);
+    } else {
+      this.previousOperand = this.currentOperand === 'Error' ? 0 : Number.parseFloat(this.currentOperand);
+    }
+
+    this.operator = operator;
+    this.shouldResetCurrent = true;
+    return this.currentOperand;
+  }
+
+  evaluate() {
+    if (!this.operator) {
+      return this.currentOperand;
+    }
+
+    const result = this.#compute();
+    this.currentOperand = formatNumber(result);
+
+    this.previousOperand = null;
+    this.operator = null;
+    this.shouldResetCurrent = true;
+
+    return this.currentOperand;
+  }
+
+  getDisplayValue() {
+    return this.currentOperand;
+  }
+
+  #compute() {
+    const current = this.currentOperand === 'Error' ? 0 : Number.parseFloat(this.currentOperand);
+    const previous = this.previousOperand ?? 0;
+
+    if (this.operator === '/' && current === 0) {
+      return null;
+    }
+
+    switch (this.operator) {
+      case '+':
+        return previous + current;
+      case '-':
+        return previous - current;
+      case '*':
+        return previous * current;
+      case '/':
+        return previous / current;
+      default:
+        return current;
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+import js from '@eslint/js';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['node_modules', 'dist']
+  },
+  {
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node
+      }
+    },
+    rules: {
+      ...js.configs.recommended.rules
+    }
+  },
+  eslintConfigPrettier
+];

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>シンプル電卓</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="calculator" aria-label="電卓">
+      <div class="calculator__display" data-display aria-live="polite">0</div>
+      <div class="calculator__keys">
+        <button type="button" class="key key--function" data-action="clear">AC</button>
+        <button type="button" class="key key--function" data-action="backspace">⌫</button>
+        <button type="button" class="key key--operator" data-operator="/">÷</button>
+        <button type="button" class="key key--operator" data-operator="*">×</button>
+
+        <button type="button" class="key" data-digit="7">7</button>
+        <button type="button" class="key" data-digit="8">8</button>
+        <button type="button" class="key" data-digit="9">9</button>
+        <button type="button" class="key key--operator" data-operator="-">−</button>
+
+        <button type="button" class="key" data-digit="4">4</button>
+        <button type="button" class="key" data-digit="5">5</button>
+        <button type="button" class="key" data-digit="6">6</button>
+        <button type="button" class="key key--operator" data-operator="+">＋</button>
+
+        <button type="button" class="key" data-digit="1">1</button>
+        <button type="button" class="key" data-digit="2">2</button>
+        <button type="button" class="key" data-digit="3">3</button>
+        <button type="button" class="key key--equals" data-action="equals">＝</button>
+
+        <button type="button" class="key key--zero" data-digit="0">0</button>
+        <button type="button" class="key" data-action="decimal">.</button>
+      </div>
+    </main>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "calculator-web",
+  "version": "1.0.0",
+  "description": "Vanilla JS web calculator with automated tests and linting.",
+  "type": "module",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "node --test",
+    "format": "prettier --check .",
+    "format:write": "prettier --write ."
+  },
+  "keywords": ["calculator", "vanilla-js"],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@eslint/js": "^9.14.0",
+    "eslint": "^9.14.0",
+    "eslint-config-prettier": "^9.1.0",
+    "globals": "^15.12.0",
+    "prettier": "^3.2.5"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,110 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
+  background-color: #f5f5f5;
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+}
+
+.calculator {
+  background-color: #1f2933;
+  border-radius: 1.5rem;
+  box-shadow: 0 20px 40px rgba(31, 41, 51, 0.3);
+  padding: 1.5rem;
+  width: min(90vw, 320px);
+  display: grid;
+  gap: 1rem;
+}
+
+.calculator__display {
+  background-color: #111822;
+  border-radius: 1rem;
+  color: #f1f5f9;
+  font-size: 2.75rem;
+  line-height: 1.4;
+  min-height: 3.5rem;
+  padding: 1rem;
+  text-align: right;
+  word-wrap: break-word;
+}
+
+.calculator__keys {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+}
+
+.key {
+  background-color: #324051;
+  border: none;
+  border-radius: 0.75rem;
+  color: #f1f5f9;
+  cursor: pointer;
+  font-size: 1.2rem;
+  font-weight: 600;
+  padding: 0.9rem;
+  transition: background-color 0.15s ease, transform 0.1s ease;
+}
+
+.key:focus-visible {
+  outline: 3px solid #38bdf8;
+  outline-offset: 2px;
+}
+
+.key:active {
+  transform: scale(0.98);
+}
+
+.key--operator {
+  background-color: #f97316;
+  color: #111822;
+}
+
+.key--operator:active {
+  background-color: #fb923c;
+}
+
+.key--equals {
+  background-color: #38bdf8;
+  color: #111822;
+  grid-row: span 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.key--equals:active {
+  background-color: #7dd3fc;
+}
+
+.key--zero {
+  grid-column: span 2;
+}
+
+.key--function {
+  background-color: #4b5563;
+}
+
+@media (max-width: 480px) {
+  .calculator {
+    border-radius: 1.25rem;
+    padding: 1rem;
+  }
+
+  .calculator__display {
+    font-size: 2.2rem;
+  }
+
+  .key {
+    font-size: 1.1rem;
+    padding: 0.75rem;
+  }
+}

--- a/test/calc.test.js
+++ b/test/calc.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Calculator } from '../calc.js';
+
+test('初期状態では表示が0になる', () => {
+  const calc = new Calculator();
+  assert.equal(calc.getDisplayValue(), '0');
+});
+
+test('数字と少数の入力が連結される', () => {
+  const calc = new Calculator();
+  calc.inputDigit('1');
+  calc.inputDigit('2');
+  calc.inputDecimal();
+  calc.inputDigit('3');
+  calc.inputDigit('4');
+  assert.equal(calc.getDisplayValue(), '12.34');
+});
+
+test('演算子を使った計算ができる', () => {
+  const calc = new Calculator();
+  calc.inputDigit('7');
+  calc.setOperator('+');
+  calc.inputDigit('5');
+  assert.equal(calc.evaluate(), '12');
+});
+
+test('連続した演算で直前の結果を使える', () => {
+  const calc = new Calculator();
+  calc.inputDigit('1');
+  calc.inputDigit('0');
+  calc.setOperator('-');
+  calc.inputDigit('2');
+  calc.setOperator('+');
+  calc.inputDigit('3');
+  assert.equal(calc.evaluate(), '11');
+});
+
+test('クリアで状態をリセットできる', () => {
+  const calc = new Calculator();
+  calc.inputDigit('9');
+  calc.setOperator('*');
+  calc.inputDigit('9');
+  calc.clear();
+  assert.equal(calc.getDisplayValue(), '0');
+  assert.equal(calc.operator, null);
+});
+
+test('Backspaceで1文字ずつ削除できる', () => {
+  const calc = new Calculator();
+  calc.inputDigit('5');
+  calc.inputDigit('0');
+  calc.backspace();
+  assert.equal(calc.getDisplayValue(), '5');
+  calc.backspace();
+  assert.equal(calc.getDisplayValue(), '0');
+});
+
+test('0で割るとErrorになる', () => {
+  const calc = new Calculator();
+  calc.inputDigit('9');
+  calc.setOperator('/');
+  calc.inputDigit('0');
+  assert.equal(calc.evaluate(), 'Error');
+});
+
+test('等号後の数字入力は新しい値になる', () => {
+  const calc = new Calculator();
+  calc.inputDigit('2');
+  calc.setOperator('*');
+  calc.inputDigit('3');
+  calc.evaluate();
+  calc.inputDigit('4');
+  assert.equal(calc.getDisplayValue(), '4');
+});


### PR DESCRIPTION
## Summary
- build a vanilla HTML/CSS/JS calculator interface with keyboard support
- implement a Calculator module with chaining, decimals, clear, backspace, and error handling
- add unit tests, lint/format configuration, MIT license, and CI workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caa928e0588331847e50c25621f541