### PR TITLE
docs: document dev server workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ npm install
 
 ## 利用方法
 
-1. `index.html` をブラウザで開きます。
-2. 画面上のボタン、もしくはキーボードの数字・演算子・Enter・Backspace・Escで入力できます。
+1. プロジェクトルートで静的サーバーを起動します。
+
+   ```bash
+   npm run serve
+   ```
+
+2. ブラウザで `http://localhost:8080` を開きます。画面上のボタン、もしくはキーボードの数字・演算子・Enter・Backspace・Escで入力できます。
 
 ## スクリプト
 
 | コマンド | 説明 |
 | --- | --- |
+| `npm run serve` | `http-server`で開発用の静的サーバーを起動します。 |
 | `npm test` | Node.js標準テストランナーでユニットテストを実行します。 |
 | `npm run lint` | ESLintで静的解析を行います。 |
 | `npm run format` | Prettierでコードフォーマットをチェックします。 |

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Vanilla JS web calculator with automated tests and linting.",
   "type": "module",
   "scripts": {
+    "serve": "http-server -c-1 -p 8080",
     "lint": "eslint .",
     "test": "node --test",
     "format": "prettier --check .",
@@ -17,6 +18,7 @@
     "eslint": "^9.14.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.12.0",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "http-server": "^14.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm script that runs http-server for local development
- document how to start the static server and access the app in the README

## Testing
- npm install *(fails: 403 Forbidden fetching @eslint/js from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cab2115f808331987319a1b97e462b